### PR TITLE
increase default volsize to 200M everywhere

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -10,6 +10,7 @@ define duplicity::backup(
   $full        = '15D',
   $archive_dir = '/root/.cache/duplicity',
   $env_var     = [],
+  $volsize     = '200',
   $args        = '--no-encryption') {
 
   file {"/usr/local/duplicity/${name}.sh":

--- a/templates/backup.erb
+++ b/templates/backup.erb
@@ -8,7 +8,7 @@ export <%= i %>
 <% end -%>
 
 duplicity --full-if-older-than <%= @full %> --name="<%= @name %>" \
-  --verbosity 0 <%= @args %> --archive-dir <%= @archive_dir %> \
+  --verbosity 0 <%= @args %> --archive-dir <%= @archive_dir %> --volsize <%= @volsize %> \
   --include-globbing-filelist /usr/local/duplicity/<%= @name %>.include \
   --exclude-globbing-filelist /usr/local/duplicity/<%= @name %>.exclude \
   <%= @source %> <%= @destination %> > <%= scope.lookupvar("duplicity::logdir") %>/<%= @name %>-$(date +%F).log 2>&1


### PR DESCRIPTION
This is the default since [duplicity v0.7.11](http://duplicity.nongnu.org/CHANGELOG), and this should fix some backup where we reach 999 archives volumes.